### PR TITLE
Fix deprecated chefspec runner config

### DIFF
--- a/spec/recipes/dsc_spec.rb
+++ b/spec/recipes/dsc_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'mixlib/shellout'
 
 describe 'powershell::dsc' do
-  let(:chef_run) { ChefSpec::Runner.new(platform: 'windows', version: '2012').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'windows', version: '2012').converge(described_recipe) }
 
   context 'When listener is enabled' do
     before do

--- a/spec/recipes/powershell2_spec.rb
+++ b/spec/recipes/powershell2_spec.rb
@@ -3,7 +3,7 @@ require 'chef/win32/version'
 
 describe 'powershell::powershell2' do
   let(:chef_run) do
-    ChefSpec::Runner.new(platform: 'windows', version: '2012') do |node|
+    ChefSpec::SoloRunner.new(platform: 'windows', version: '2012') do |node|
       node.set['powershell']['powershell2']['url'] = 'https://powershelltest.com'
       node.set['powershell']['powershell2']['checksum'] = '12345'
     end.converge(described_recipe)

--- a/spec/recipes/powershell3_spec.rb
+++ b/spec/recipes/powershell3_spec.rb
@@ -3,7 +3,7 @@ require 'chef/win32/version'
 
 describe 'powershell::powershell3' do
   let(:chef_run) do
-    ChefSpec::Runner.new(platform: 'windows', version: '2012') do |node|
+    ChefSpec::SoloRunner.new(platform: 'windows', version: '2012') do |node|
       node.set['powershell']['powershell3']['url'] = 'https://powershelltest.com'
       node.set['powershell']['powershell3']['checksum'] = '12345'
       node.set['powershell']['bits_4']['url'] = 'https://powershellbits.com'

--- a/spec/recipes/powershell4_spec.rb
+++ b/spec/recipes/powershell4_spec.rb
@@ -4,7 +4,7 @@ require 'chef/win32/version'
 describe 'powershell::powershell4' do
   context 'when installation_reboot_mode is no_reboot' do
     let(:chef_run) do
-      ChefSpec::Runner.new(platform: 'windows', version: '2012') do |node|
+      ChefSpec::SoloRunner.new(platform: 'windows', version: '2012') do |node|
         node.set['powershell']['powershell4']['url'] = 'https://powershelltest.com'
         node.set['powershell']['powershell4']['checksum'] = '12345'
         node.set['powershell']['installation_reboot_mode'] = 'no_reboot'
@@ -86,7 +86,7 @@ describe 'powershell::powershell4' do
 
   context 'when installation_reboot_mode is delayed_reboot' do
     let(:chef_run) do
-      ChefSpec::Runner.new(platform: 'windows', version: '2012') do |node|
+      ChefSpec::SoloRunner.new(platform: 'windows', version: '2012') do |node|
         node.set['powershell']['powershell4']['url'] = 'https://powershelltest.com'
         node.set['powershell']['powershell4']['checksum'] = '12345'
         node.set['powershell']['installation_reboot_mode'] = 'delayed_reboot'
@@ -168,7 +168,7 @@ describe 'powershell::powershell4' do
 
   context 'when installation_reboot_mode is immediate_reboot' do
     let(:chef_run) do
-      ChefSpec::Runner.new(platform: 'windows', version: '2012') do |node|
+      ChefSpec::SoloRunner.new(platform: 'windows', version: '2012') do |node|
         node.set['powershell']['powershell4']['url'] = 'https://powershelltest.com'
         node.set['powershell']['powershell4']['checksum'] = '12345'
         node.set['powershell']['installation_reboot_mode'] = 'immediate_reboot'

--- a/spec/recipes/powershell5_spec.rb
+++ b/spec/recipes/powershell5_spec.rb
@@ -3,7 +3,7 @@ require 'chef/win32/version'
 
 describe 'powershell::powershell5' do
   let(:chef_run) do
-    ChefSpec::Runner.new(platform: 'windows', version: '2012') do |node|
+    ChefSpec::SoloRunner.new(platform: 'windows', version: '2012') do |node|
       node.set['powershell']['powershell5']['url'] = 'https://powershelltest.com'
       node.set['powershell']['powershell5']['checksum'] = '12345'
     end.converge(described_recipe)

--- a/spec/recipes/winrm_spec.rb
+++ b/spec/recipes/winrm_spec.rb
@@ -3,7 +3,7 @@ require 'chef/win32/version'
 
 describe 'powershell::winrm' do
   let(:chef_run) do
-    ChefSpec::Runner.new(platform: 'windows', version: '2012').converge(described_recipe)
+    ChefSpec::SoloRunner.new(platform: 'windows', version: '2012').converge(described_recipe)
   end
 
   it 'installs windows package windows managemet framework core 5.0' do


### PR DESCRIPTION
Update chefspec runner to current standard, as shown in examples: https://github.com/sethvargo/chefspec#writing-a-cookbook-example