### PR TITLE
Powershell reboot fixes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,10 @@ if node['platform_family'] == 'windows'
   # INSTALLATION_REBOOT_MODE = "delayed_reboot". Used for node reboot after chef-client run.
   default['powershell']['installation_reboot_mode'] = ENV['INSTALLATION_REBOOT_MODE'] || 'no_reboot'
 
+  # number of seconds to warn before reboot. The clock starts at the end of the
+  # chef run.
+  default['powershell']['reboot_timeout_seconds'] = 10
+
   # For enabling HTTPS transport in winrm recipe
   default['powershell']['winrm']['enable_https_transport'] = false
   default['powershell']['winrm']['thumbprint'] = ''		# mandatory for https transport

--- a/attributes/powershell4.rb
+++ b/attributes/powershell4.rb
@@ -38,4 +38,3 @@ if node['platform_family'] == 'windows'
   end
 end
 
-default['powershell']['reboot_notifier'] = 'windows_package[Windows Management Framework Core4.0]'

--- a/recipes/powershell2.rb
+++ b/recipes/powershell2.rb
@@ -61,12 +61,18 @@ when 'windows'
 
     include_recipe 'ms_dotnet2'
 
+    # Reboot if user specifies doesn't specify no_reboot
+    include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
+
     windows_package 'Windows Management Framework Core' do
       source node['powershell']['powershell2']['url']
       checksum node['powershell']['powershell2']['checksum']
       installer_type :custom
       options '/quiet /norestart'
       action :install
+      # Note that the :immediately is to immediately notify the other resource,
+      # not to immediately reboot. The windows_reboot 'notifies' does that.
+      notifies :request, 'windows_reboot[powershell]', :immediately unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
       not_if do
         begin
           registry_data_exists?('HKLM\SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine', { :name => 'PowerShellVersion', :type => :string, :data => '2.0' })

--- a/recipes/powershell3.rb
+++ b/recipes/powershell3.rb
@@ -53,6 +53,7 @@ when 'windows'
       checksum node['powershell']['powershell3']['checksum']
       installer_type :custom
       options '/quiet /norestart'
+      success_codes [0, 42, 127, 3010]
       action :install
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.

--- a/recipes/powershell3.rb
+++ b/recipes/powershell3.rb
@@ -45,12 +45,18 @@ when 'windows'
     # WMF 3.0 requires .NET 4.0
     include_recipe 'ms_dotnet4'
 
+    # Reboot if user specifies doesn't specify no_reboot
+    include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot' 
+
     windows_package 'Windows Management Framework Core 3.0' do
       source node['powershell']['powershell3']['url']
       checksum node['powershell']['powershell3']['checksum']
       installer_type :custom
       options '/quiet /norestart'
       action :install
+      # Note that the :immediately is to immediately notify the other resource,
+      # not to immediately reboot. The windows_reboot 'notifies' does that.
+      notifies :request, 'windows_reboot[powershell]', :immediately unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
       not_if do
         begin
           registry_data_exists?('HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', { :name => 'PowerShellVersion', :type => :string, :data => '3.0' })

--- a/recipes/powershell4.rb
+++ b/recipes/powershell4.rb
@@ -30,14 +30,8 @@ if node['platform'] == 'windows'
     # Ensure .NET 4.5 is installed or installation will fail silently per Microsoft. Only necessary for Windows 2008R2 or 7.
     include_recipe 'ms_dotnet45' if windows_version.windows_server_2008_r2? || windows_version.windows_7?
 
-    # Get powershell version
-    powershell_version_cmd = 'powershell.exe $PSVersionTable.PSVersion.Major'
-    shell_out = Mixlib::ShellOut.new(powershell_version_cmd)
-    shell_out.run_command
-    powershell_version = shell_out.stdout.to_f
-
-    # Reboot if user specifies doesn't specify no_reboot and powershell version < 4
-    include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot' && powershell_version < 4
+    # Reboot if user specifies doesn't specify no_reboot
+    include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
 
     windows_package 'Windows Management Framework Core4.0' do
       source node['powershell']['powershell4']['url']

--- a/recipes/powershell4.rb
+++ b/recipes/powershell4.rb
@@ -30,8 +30,14 @@ if node['platform'] == 'windows'
     # Ensure .NET 4.5 is installed or installation will fail silently per Microsoft. Only necessary for Windows 2008R2 or 7.
     include_recipe 'ms_dotnet45' if windows_version.windows_server_2008_r2? || windows_version.windows_7?
 
-    # Reboot if user specifies immediate_reboot
-    include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
+    # Get powershell version
+    powershell_version_cmd = 'powershell.exe $PSVersionTable.PSVersion.Major'
+    shell_out = Mixlib::ShellOut.new(powershell_version_cmd)
+    shell_out.run_command
+    powershell_version = shell_out.stdout.to_f
+
+    # Reboot if user specifies doesn't specify no_reboot and powershell version < 4
+    include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot' && powershell_version < 4
 
     windows_package 'Windows Management Framework Core4.0' do
       source node['powershell']['powershell4']['url']
@@ -40,6 +46,8 @@ if node['platform'] == 'windows'
       options '/quiet /norestart'
       action :install
       success_codes [0, 42, 127, 3010]
+      # Note that the :immediately is to immediately notify the other resource,
+      # not to immediately reboot. The windows_reboot 'notifies' does that. 
       notifies :request, 'windows_reboot[powershell]', :immediately unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
       not_if do
         begin

--- a/recipes/powershell5.rb
+++ b/recipes/powershell5.rb
@@ -31,12 +31,17 @@ when 'windows'
 
   if windows_version.windows_server_2012_r2? || windows_version.windows_8_1?
 
+    include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
+
     windows_package 'Windows Management Framework Core 5.0' do
       source node['powershell']['powershell5']['url']
       checksum node['powershell']['powershell5']['checksum']
       installer_type :custom
       options '/quiet /norestart'
       action :install
+      # Note that the :immediately is to immediately notify the other resource,
+      # not to immediately reboot. The windows_reboot 'notifies' does that.
+      notifies :request, 'windows_reboot[powershell]', :immediately unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
       not_if { registry_data_exists?('HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', { :name => 'PowerShellVersion', :type => :string, :data => '5.0.9701.0' }) }
     end
 

--- a/recipes/windows_reboot.rb
+++ b/recipes/windows_reboot.rb
@@ -7,7 +7,6 @@ include_recipe 'windows::reboot_handler'
 windows_reboot 'powershell' do
   reason 'Reboot after successful/unsuccessful powershell installation'
   timeout 60
-#  notifies :run, node['powershell']['reboot_notifier'], :immediately
   action :nothing
   notifies :run, 'ruby_block[end_chef_run]', :immediately if node['powershell']['installation_reboot_mode'] == 'immediate_reboot'
 end

--- a/recipes/windows_reboot.rb
+++ b/recipes/windows_reboot.rb
@@ -6,7 +6,7 @@ include_recipe 'windows::reboot_handler'
 
 windows_reboot 'powershell' do
   reason 'Reboot after successful/unsuccessful powershell installation'
-  timeout 60
+  timeout 10
   action :nothing
   notifies :run, 'ruby_block[end_chef_run]', :immediately if node['powershell']['installation_reboot_mode'] == 'immediate_reboot'
 end
@@ -15,7 +15,7 @@ end
 # needs to happen straight away to be useful, throw an exception...
 ruby_block 'end_chef_run' do
   block do
-    raise 'Requested sudden and early end to the run... I hope this was justified.'
+    raise 'Requested sudden end to the run... I hope this was justified.'
   end
   action :nothing
 end

--- a/recipes/windows_reboot.rb
+++ b/recipes/windows_reboot.rb
@@ -6,7 +6,7 @@ include_recipe 'windows::reboot_handler'
 
 windows_reboot 'powershell' do
   reason 'Reboot after successful/unsuccessful powershell installation'
-  timeout 10
+  timeout node['powershell']['reboot_timeout_seconds']
   action :nothing
   notifies :run, 'ruby_block[end_chef_run]', :immediately if node['powershell']['installation_reboot_mode'] == 'immediate_reboot'
 end

--- a/recipes/windows_reboot.rb
+++ b/recipes/windows_reboot.rb
@@ -4,9 +4,20 @@ node.default['windows']['allow_reboot_on_failure'] = true
 
 include_recipe 'windows::reboot_handler'
 
-windows_reboot 'rebooter' do
+windows_reboot 'powershell' do
   reason 'Reboot after successful/unsuccessful powershell installation'
   timeout 60
-  notifies :run, node['powershell']['reboot_notifier'], :immediately
-  not_if { false }
+#  notifies :run, node['powershell']['reboot_notifier'], :immediately
+  action :nothing
+  notifies :run, 'ruby_block[end_chef_run]', :immediately if node['powershell']['installation_reboot_mode'] == 'immediate_reboot'
 end
+
+# The reboot handler only does something at the end of the chef run. If it
+# needs to happen straight away to be useful, throw an exception...
+ruby_block 'end_chef_run' do
+  block do
+    raise 'Requested sudden and early end to the run... I hope this was justified.'
+  end
+  action :nothing
+end
+


### PR DESCRIPTION
I've switched around some of the logic here and added in a ruby_block to explicitly raise an exception - which is needed for the reboot_handler to actually reboot the node prior to the usual end of the run.

Previously the powershellX recipes were only including the windows_reboot recipe for immediate reboots but it is also needed for delayed reboots.

I also added the /norestart and /quiet flags back. Both are needed to reboot 'gracefully' in a way visible to chef.

Added an extra return code which seems to be thrown when a reboot is required (3010).

In windows_reboot added ruby_block to raise an exception if an immediate reboot is required. It does nothing otherwise.

Unless no_reboot is set, the reboot will still happen at the end of the chef run with no exception.

I think this PR can replace #36 from @zl4bv but probably also #32 from @NimishaS. 

These changes have been tested with Windows 2008r2 Standard. 
